### PR TITLE
feat: add CorsConfig

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -38,6 +38,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
@@ -57,6 +58,10 @@
 				<exclusion>
 					<groupId>org.bouncycastle</groupId>
 					<artifactId>bcprov-jdk15on</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/backend/src/main/java/com/pickme/config/CorsConfig.java
+++ b/backend/src/main/java/com/pickme/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package com.pickme.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("*")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,7 +14,7 @@ aws.s3.bucket-name=${YOUR_BUCKET_NAME}
 
 google.books.api.key=${API_KEY_BOOKS}
 
-spring.profiles.active=dev
+spring.profiles.active=prod
 
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587


### PR DESCRIPTION
- Implemented global CORS configuration for the backend
- Allowed requests from http://localhost:3000
- Changed active profile to `prod` in application.properties
- Excluded `commons-logging` from AWS S3 dependency to avoid logging conflicts